### PR TITLE
Add Atelier Lakeside Dark theme for cutty-agent project

### DIFF
--- a/kitty/theme-switcher.sh
+++ b/kitty/theme-switcher.sh
@@ -80,6 +80,9 @@ switch_kitty_theme() {
         *cloudflare-ai-worker*)
             $KITTY @ set-colors "$HOME/.config/kitty/Mona Lisa.conf" 2>/dev/null
             ;;
+        *cutty-agent*)
+            $KITTY @ set-colors "$HOME/.config/kitty/Atelier Lakeside Dark.conf" 2>/dev/null
+            ;;
         *)
             # Default - keep current theme
             ;;


### PR DESCRIPTION
## Summary
- Added cutty-agent project mapping to kitty theme-switcher.sh
- Configured to use Atelier Lakeside Dark theme
- Theme activates automatically when navigating to directories containing "cutty-agent"

## Test plan
- [ ] Navigate to a directory containing "cutty-agent" in the path
- [ ] Verify that kitty terminal theme changes to Atelier Lakeside Dark
- [ ] Navigate away and verify theme changes back appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)